### PR TITLE
Bug-fix for Heredoc syntax "Parse error: Invalid body indentation level (expecting an indentation level of at least 1)"

### DIFF
--- a/cdc_audit_gen_mysql.php
+++ b/cdc_audit_gen_mysql.php
@@ -406,7 +406,7 @@ DROP TRIGGER IF EXISTS `%1$s`;
 
 END;
 
-        $triggers_mask = <<< 'END'
+        $triggers_mask = '
 -- %1$s after INSERT trigger.
 DELIMITER @@
 CREATE TRIGGER `%1$s_after_insert` AFTER INSERT ON `%1$s`
@@ -436,7 +436,7 @@ CREATE TRIGGER `%1$s_after_delete` AFTER DELETE ON `%1$s`
 %9$s
  END;
 @@
-END;
+';
 
         $table_audit = $this->table_audit( $table );
 


### PR DESCRIPTION
Think this issue exists since PHP 7.3, see https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc